### PR TITLE
Fix: 대화 생성 시 불필요한 사용량 체크 제거

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,11 +52,11 @@ spring:
           filters:
             - name: JwtAuthenticationFilter
 
-        # POST /conversations/** - 사용량 체크 필요
-        - id: ai-conversations-post-route
+        # POST /conversations/*/messages - 사용량 체크 필요 (메시지 전송)
+        - id: ai-conversations-messages-post-route
           uri: ${AI_SERVER_URL:http://localhost:8001}
           predicates:
-            - Path=/conversations/**
+            - Path=/conversations/*/messages
             - Method=POST
           filters:
             - name: JwtAuthenticationFilter
@@ -64,7 +64,7 @@ spring:
               args:
                 action: AI_CHAT
 
-        # 기타 /conversations/** - 사용량 체크 불필요
+        # 기타 /conversations/** - 사용량 체크 불필요 (대화 생성 포함)
         - id: ai-conversations-route
           uri: ${AI_SERVER_URL:http://localhost:8001}
           predicates:


### PR DESCRIPTION
### 관련 이슈 #3 

### 변경 사항
POST /conversations/** 전체에 적용되던 UsageLimitCheckFilter를 POST /conversations/*/messages에만 적용하도록 수정                                                                                                               
  - 대화 생성(POST /conversations)은 캐릭터 생성 또는 채팅 시작 시 호출되며,사용량 제한 대상이 아님                                                         
  - 사용량 체크는 실제 메시지 전송(POST /conversations/{id}/messages) 시에만 필요함                                                                          
                                          